### PR TITLE
room-data-base-structure-added

### DIFF
--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -21,6 +21,7 @@ ext {
     mockitocore = "2.28.2"
     mockitoinline = "2.21.0"
     koin_viewmodel = "2.0.0-GA"
+    roomversion = "2.2.5"
 
     generalDependencies = [
             kotlin                  : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin}",
@@ -44,6 +45,10 @@ ext {
             mockitokotlin2          : "com.nhaarman.mockitokotlin2:mockito-kotlin:${mockitokotlin2}",
             mockitocore             : "org.mockito:mockito-core:${mockitocore}",
             mockitoinline           : "org.mockito:mockito-inline:${mockitoinline}",
-            koinviewmodel           : "org.koin:koin-androidx-viewmodel:${koin_viewmodel}"
+            koinviewmodel           : "org.koin:koin-androidx-viewmodel:${koin_viewmodel}",
+            roomruntime             : "androidx.room:room-runtime:${roomversion}",
+            roomcompiler            : "androidx.room:room-compiler:${roomversion}",
+            roomktx                 : "androidx.room:room-ktx:${roomversion}",
+            roomtesting             : "androidx.room:room-testing:${roomversion}"
     ]
 }

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 29
@@ -32,5 +33,9 @@ dependencies {
 
     implementation lib.retrofit
     implementation lib.retrofitgson
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation lib.roomruntime
+    kapt lib.roomcompiler
+    implementation lib.roomktx
+    androidTestImplementation lib.roomtesting
+    implementation lib.androidxlifecycle
 }

--- a/data/src/main/java/com/globant/data/database/MemeDao.kt
+++ b/data/src/main/java/com/globant/data/database/MemeDao.kt
@@ -1,0 +1,26 @@
+package com.globant.data.database
+
+import androidx.lifecycle.LiveData
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.globant.domain.entity.MemeDetailRoom
+import com.globant.domain.entity.MemeRoom
+
+@Dao
+interface MemeDao {
+
+    @Query("SELECT * FROM meme_table")
+    fun getMemes(): LiveData<List<MemeRoom>>
+
+    @Query("SELECT * FROM memeDetail_table WHERE id = :memeId")
+    fun getMemeById(memeId: Int): LiveData<MemeDetailRoom>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    fun insertMeme(meme: MemeRoom)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    fun insertMemeDetail(memeDetail: MemeDetailRoom)
+
+}

--- a/data/src/main/java/com/globant/data/database/MemeRoomDataBaseImpl.kt
+++ b/data/src/main/java/com/globant/data/database/MemeRoomDataBaseImpl.kt
@@ -11,17 +11,11 @@ abstract class MemeRoomDataBaseImpl : RoomDatabase(), MemeRoomDataBase {
 
     abstract fun memeDao(): MemeDao
 
-    override fun getAllMemesFromDataBase(): List<MemeRoom> {
-        lateinit var listOfMemes: List<MemeRoom>
-        memeDao().getMemes().value?.let { listOfMemes = it }
-        return listOfMemes
-    }
+    override fun getAllMemesFromDataBase(): List<MemeRoom> =
+        memeDao().getMemes().value ?: listOf()
 
-    override fun getMemeByIdFromDataBase(memeId: Int): MemeDetailRoom {
-        lateinit var memeDetail: MemeDetailRoom
-        memeDao().getMemeById(memeId).value?.let { memeDetail = it }
-        return memeDetail
-    }
+    override fun getMemeByIdFromDataBase(memeId: Int): MemeDetailRoom =
+        memeDao().getMemeById(memeId).value ?: MemeDetailRoom()
 
     override fun updateMemeDetailInDataBase(memeDetail: MemeDetailRoom) {
         memeDao().insertMemeDetail(memeDetail)

--- a/data/src/main/java/com/globant/data/database/MemeRoomDataBaseImpl.kt
+++ b/data/src/main/java/com/globant/data/database/MemeRoomDataBaseImpl.kt
@@ -1,0 +1,35 @@
+package com.globant.data.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.globant.domain.entity.MemeRoom
+import com.globant.domain.database.MemeRoomDataBase
+import com.globant.domain.entity.MemeDetailRoom
+
+@Database(entities = [MemeRoom::class, MemeDetailRoom::class], version = 1)
+abstract class MemeRoomDataBaseImpl : RoomDatabase(), MemeRoomDataBase {
+
+    abstract fun memeDao(): MemeDao
+
+    override fun getAllMemesFromDataBase(): List<MemeRoom> {
+        lateinit var listOfMemes: List<MemeRoom>
+        memeDao().getMemes().value?.let { listOfMemes = it }
+        return listOfMemes
+    }
+
+    override fun getMemeByIdFromDataBase(memeId: Int): MemeDetailRoom {
+        lateinit var memeDetail: MemeDetailRoom
+        memeDao().getMemeById(memeId).value?.let { memeDetail = it }
+        return memeDetail
+    }
+
+    override fun updateMemeDetailInDataBase(memeDetail: MemeDetailRoom) {
+        memeDao().insertMemeDetail(memeDetail)
+    }
+
+    override fun updateMemesInDataBase(listOfMeme: List<MemeRoom>) {
+        listOfMeme.forEach {
+            memeDao().insertMeme(it)
+        }
+    }
+}

--- a/di/build.gradle
+++ b/di/build.gradle
@@ -31,5 +31,6 @@ dependencies {
     implementation project(path: ':data')
     def lib = rootProject.ext.generalDependencies
 
+    implementation lib.roomruntime
     implementation lib.koinviewmodel
 }

--- a/di/src/main/java/com/globant/di/KoinModules.kt
+++ b/di/src/main/java/com/globant/di/KoinModules.kt
@@ -1,18 +1,39 @@
 package com.globant.di
 
+import androidx.room.Room
+import com.globant.data.database.MemeRoomDataBaseImpl
 import com.globant.data.service.MemeServiceImpl
 import com.globant.domain.service.MemeService
-import com.globant.domain.usecase.GetMemeByIdUseCase
+import com.globant.domain.usecase.UpdateMemeDetailsDataBaseUseCase
+import com.globant.domain.usecase.UpdateMemesDataBaseUseCase
+import com.globant.domain.usecase.GetMemesFromDataBaseUseCase
+import com.globant.domain.usecase.GetMemeByIdFromDataBaseUseCase
 import com.globant.domain.usecase.GetMemesUseCase
+import com.globant.domain.usecase.GetMemeByIdUseCase
+import com.globant.domain.usecase.implementation.UpdateMemesDataBaseUseCaseImpl
+import com.globant.domain.usecase.implementation.UpdateMemeDetailsDataBaseUseCaseImpl
+import com.globant.domain.usecase.implementation.GetMemesFromDataBaseUseCaseImpl
+import com.globant.domain.usecase.implementation.GetMemeByIdFromDataBaseUseCaseImpl
 import com.globant.domain.usecase.implementation.GetMemeByIdUseCaseImpl
 import com.globant.domain.usecase.implementation.GetMemesUseCaseImpl
 import org.koin.dsl.module
 
 val servicesModule = module {
-    single <MemeService> { MemeServiceImpl() }
+    single<MemeService> { MemeServiceImpl() }
 }
 
 val useCasesModule = module {
-    single <GetMemesUseCase> { GetMemesUseCaseImpl(get()) }
-    single <GetMemeByIdUseCase> { GetMemeByIdUseCaseImpl(get()) }
+    single<GetMemesUseCase> { GetMemesUseCaseImpl(get()) }
+    single<GetMemeByIdUseCase> { GetMemeByIdUseCaseImpl(get()) }
+    single<GetMemeByIdFromDataBaseUseCase> { GetMemeByIdFromDataBaseUseCaseImpl(get()) }
+    single<GetMemesFromDataBaseUseCase> { GetMemesFromDataBaseUseCaseImpl(get()) }
+    single<UpdateMemesDataBaseUseCase> { UpdateMemesDataBaseUseCaseImpl(get()) }
+    single<UpdateMemeDetailsDataBaseUseCase> { UpdateMemeDetailsDataBaseUseCaseImpl(get()) }
 }
+
+val dataBaseModule = module {
+    single { Room.databaseBuilder(get(), MemeRoomDataBaseImpl::class.java, DATA_BASE_NAME).build() }
+    single { get<MemeRoomDataBaseImpl>().memeDao() }
+}
+
+private const val DATA_BASE_NAME = "memeDataBase"

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -3,5 +3,8 @@ apply plugin: 'kotlin'
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    def lib = rootProject.ext.generalDependencies
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation lib.roomruntime
 }

--- a/domain/src/main/java/com/globant/domain/database/MemeRoomDataBase.kt
+++ b/domain/src/main/java/com/globant/domain/database/MemeRoomDataBase.kt
@@ -1,0 +1,11 @@
+package com.globant.domain.database
+
+import com.globant.domain.entity.MemeDetailRoom
+import com.globant.domain.entity.MemeRoom
+
+interface MemeRoomDataBase {
+    fun getAllMemesFromDataBase(): List<MemeRoom>
+    fun getMemeByIdFromDataBase(memeId: Int): MemeDetailRoom
+    fun updateMemesInDataBase(listOfMeme: List<MemeRoom>)
+    fun updateMemeDetailInDataBase(memeDetail: MemeDetailRoom)
+}

--- a/domain/src/main/java/com/globant/domain/entity/MemeDetailRoom.kt
+++ b/domain/src/main/java/com/globant/domain/entity/MemeDetailRoom.kt
@@ -1,15 +1,16 @@
 package com.globant.domain.entity
 
-import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.globant.domain.util.DEFAULT_ID
+import com.globant.domain.util.DEFAULT_STRING
 
 @Entity(tableName = "memeDetail_table")
 class MemeDetailRoom(
-    @PrimaryKey @ColumnInfo(name = "id") val id: Int,
-    @ColumnInfo(name = "origin") val origin: String,
-    @ColumnInfo(name = "image") val image: String,
-    @ColumnInfo(name = "name") val name: String,
-    @ColumnInfo(name = "rank") val rank: String,
-    @ColumnInfo(name = "tags") val tags: String
+    @PrimaryKey val id: Int = DEFAULT_ID,
+    val origin: String = DEFAULT_STRING,
+    val image: String = DEFAULT_STRING,
+    val name: String = DEFAULT_STRING,
+    val rank: String = DEFAULT_STRING,
+    val tags: String = DEFAULT_STRING
 )

--- a/domain/src/main/java/com/globant/domain/entity/MemeDetailRoom.kt
+++ b/domain/src/main/java/com/globant/domain/entity/MemeDetailRoom.kt
@@ -1,0 +1,15 @@
+package com.globant.domain.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "memeDetail_table")
+class MemeDetailRoom(
+    @PrimaryKey @ColumnInfo(name = "id") val id: Int,
+    @ColumnInfo(name = "origin") val origin: String,
+    @ColumnInfo(name = "image") val image: String,
+    @ColumnInfo(name = "name") val name: String,
+    @ColumnInfo(name = "rank") val rank: String,
+    @ColumnInfo(name = "tags") val tags: String
+)

--- a/domain/src/main/java/com/globant/domain/entity/MemeRoom.kt
+++ b/domain/src/main/java/com/globant/domain/entity/MemeRoom.kt
@@ -3,11 +3,14 @@ package com.globant.domain.entity;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.PrimaryKey;
+import com.globant.domain.util.DEFAULT_ID
+import com.globant.domain.util.DEFAULT_INT
+import com.globant.domain.util.DEFAULT_STRING
 
 @Entity(tableName = "meme_table")
 class MemeRoom(
-    @PrimaryKey @ColumnInfo(name = "ID") val ID: Int,
-    @ColumnInfo(name = "image") val image: String,
-    @ColumnInfo(name = "name") val name: String,
-    @ColumnInfo(name = "rank") val rank: Int
+    @PrimaryKey val ID: Int = DEFAULT_ID,
+    val image: String = DEFAULT_STRING,
+    val name: String = DEFAULT_STRING,
+    val rank: Int = DEFAULT_INT
 )

--- a/domain/src/main/java/com/globant/domain/entity/MemeRoom.kt
+++ b/domain/src/main/java/com/globant/domain/entity/MemeRoom.kt
@@ -1,0 +1,13 @@
+package com.globant.domain.entity;
+
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+@Entity(tableName = "meme_table")
+class MemeRoom(
+    @PrimaryKey @ColumnInfo(name = "ID") val ID: Int,
+    @ColumnInfo(name = "image") val image: String,
+    @ColumnInfo(name = "name") val name: String,
+    @ColumnInfo(name = "rank") val rank: Int
+)

--- a/domain/src/main/java/com/globant/domain/usecase/GetMemeByIdFromDataBaseUseCase.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/GetMemeByIdFromDataBaseUseCase.kt
@@ -1,0 +1,7 @@
+package com.globant.domain.usecase
+
+import com.globant.domain.entity.MemeDetailRoom
+
+interface GetMemeByIdFromDataBaseUseCase {
+    fun invoke(memeId: Int): MemeDetailRoom
+}

--- a/domain/src/main/java/com/globant/domain/usecase/GetMemesFromDataBaseUseCase.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/GetMemesFromDataBaseUseCase.kt
@@ -1,0 +1,7 @@
+package com.globant.domain.usecase
+
+import com.globant.domain.entity.MemeRoom
+
+interface GetMemesFromDataBaseUseCase {
+    fun invoke(): List<MemeRoom>
+}

--- a/domain/src/main/java/com/globant/domain/usecase/UpdateMemeDetailsDataBaseUseCase.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/UpdateMemeDetailsDataBaseUseCase.kt
@@ -1,0 +1,7 @@
+package com.globant.domain.usecase
+
+import com.globant.domain.entity.MemeDetailRoom
+
+interface UpdateMemeDetailsDataBaseUseCase {
+    fun invoke(memeDetail: MemeDetailRoom)
+}

--- a/domain/src/main/java/com/globant/domain/usecase/UpdateMemesDataBaseUseCase.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/UpdateMemesDataBaseUseCase.kt
@@ -1,0 +1,7 @@
+package com.globant.domain.usecase
+
+import com.globant.domain.entity.MemeRoom
+
+interface UpdateMemesDataBaseUseCase {
+    fun invoke(listOfMeme: List<MemeRoom>)
+}

--- a/domain/src/main/java/com/globant/domain/usecase/implementation/GetMemeByIdFromDataBaseUseCaseImpl.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/implementation/GetMemeByIdFromDataBaseUseCaseImpl.kt
@@ -1,0 +1,11 @@
+package com.globant.domain.usecase.implementation
+
+import com.globant.domain.database.MemeRoomDataBase
+import com.globant.domain.entity.MemeDetailRoom
+import com.globant.domain.usecase.GetMemeByIdFromDataBaseUseCase
+
+class GetMemeByIdFromDataBaseUseCaseImpl(private val memeDataBase: MemeRoomDataBase) :
+    GetMemeByIdFromDataBaseUseCase {
+    override fun invoke(memeId: Int): MemeDetailRoom =
+        memeDataBase.getMemeByIdFromDataBase(memeId)
+}

--- a/domain/src/main/java/com/globant/domain/usecase/implementation/GetMemeByIdFromDataBaseUseCaseImpl.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/implementation/GetMemeByIdFromDataBaseUseCaseImpl.kt
@@ -4,8 +4,6 @@ import com.globant.domain.database.MemeRoomDataBase
 import com.globant.domain.entity.MemeDetailRoom
 import com.globant.domain.usecase.GetMemeByIdFromDataBaseUseCase
 
-class GetMemeByIdFromDataBaseUseCaseImpl(private val memeDataBase: MemeRoomDataBase) :
-    GetMemeByIdFromDataBaseUseCase {
-    override fun invoke(memeId: Int): MemeDetailRoom =
-        memeDataBase.getMemeByIdFromDataBase(memeId)
+class GetMemeByIdFromDataBaseUseCaseImpl(private val memeDataBase: MemeRoomDataBase) : GetMemeByIdFromDataBaseUseCase {
+    override fun invoke(memeId: Int): MemeDetailRoom = memeDataBase.getMemeByIdFromDataBase(memeId)
 }

--- a/domain/src/main/java/com/globant/domain/usecase/implementation/GetMemeByIdUseCaseImpl.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/implementation/GetMemeByIdUseCaseImpl.kt
@@ -6,6 +6,5 @@ import com.globant.domain.usecase.GetMemeByIdUseCase
 import com.globant.domain.util.Result
 
 class GetMemeByIdUseCaseImpl(private val memeService: MemeService) : GetMemeByIdUseCase {
-    override fun invoke(memeId: Int): Result<MemeDetail> =
-            memeService.getMemeByIdFromApi(memeId)
+    override fun invoke(memeId: Int): Result<MemeDetail> = memeService.getMemeByIdFromApi(memeId)
 }

--- a/domain/src/main/java/com/globant/domain/usecase/implementation/GetMemesFromDataBaseUseCaseImpl.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/implementation/GetMemesFromDataBaseUseCaseImpl.kt
@@ -1,0 +1,11 @@
+package com.globant.domain.usecase.implementation
+
+import com.globant.domain.database.MemeRoomDataBase
+import com.globant.domain.entity.MemeRoom
+import com.globant.domain.usecase.GetMemesFromDataBaseUseCase
+
+class GetMemesFromDataBaseUseCaseImpl(private val memeDataBase: MemeRoomDataBase) :
+    GetMemesFromDataBaseUseCase {
+    override fun invoke(): List<MemeRoom> =
+        memeDataBase.getAllMemesFromDataBase()
+}

--- a/domain/src/main/java/com/globant/domain/usecase/implementation/GetMemesFromDataBaseUseCaseImpl.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/implementation/GetMemesFromDataBaseUseCaseImpl.kt
@@ -4,8 +4,6 @@ import com.globant.domain.database.MemeRoomDataBase
 import com.globant.domain.entity.MemeRoom
 import com.globant.domain.usecase.GetMemesFromDataBaseUseCase
 
-class GetMemesFromDataBaseUseCaseImpl(private val memeDataBase: MemeRoomDataBase) :
-    GetMemesFromDataBaseUseCase {
-    override fun invoke(): List<MemeRoom> =
-        memeDataBase.getAllMemesFromDataBase()
+class GetMemesFromDataBaseUseCaseImpl(private val memeDataBase: MemeRoomDataBase) : GetMemesFromDataBaseUseCase {
+    override fun invoke(): List<MemeRoom> = memeDataBase.getAllMemesFromDataBase()
 }

--- a/domain/src/main/java/com/globant/domain/usecase/implementation/GetMemesUseCaseImpl.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/implementation/GetMemesUseCaseImpl.kt
@@ -6,6 +6,5 @@ import com.globant.domain.usecase.GetMemesUseCase
 import com.globant.domain.util.Result
 
 class GetMemesUseCaseImpl(private val memeService: MemeService) : GetMemesUseCase {
-    override fun invoke(): Result<List<Meme>> =
-            memeService.getMemesFromApi()
+    override fun invoke(): Result<List<Meme>> = memeService.getMemesFromApi()
 }

--- a/domain/src/main/java/com/globant/domain/usecase/implementation/UpdateMemeDetailsDataBaseUseCaseImpl.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/implementation/UpdateMemeDetailsDataBaseUseCaseImpl.kt
@@ -1,0 +1,12 @@
+package com.globant.domain.usecase.implementation
+
+import com.globant.domain.database.MemeRoomDataBase
+import com.globant.domain.entity.MemeDetailRoom
+import com.globant.domain.usecase.UpdateMemeDetailsDataBaseUseCase
+
+class UpdateMemeDetailsDataBaseUseCaseImpl(private val memeDataBase: MemeRoomDataBase) :
+    UpdateMemeDetailsDataBaseUseCase {
+    override fun invoke(memeDetail: MemeDetailRoom) {
+        memeDataBase.updateMemeDetailInDataBase(memeDetail)
+    }
+}

--- a/domain/src/main/java/com/globant/domain/usecase/implementation/UpdateMemeDetailsDataBaseUseCaseImpl.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/implementation/UpdateMemeDetailsDataBaseUseCaseImpl.kt
@@ -4,8 +4,7 @@ import com.globant.domain.database.MemeRoomDataBase
 import com.globant.domain.entity.MemeDetailRoom
 import com.globant.domain.usecase.UpdateMemeDetailsDataBaseUseCase
 
-class UpdateMemeDetailsDataBaseUseCaseImpl(private val memeDataBase: MemeRoomDataBase) :
-    UpdateMemeDetailsDataBaseUseCase {
+class UpdateMemeDetailsDataBaseUseCaseImpl(private val memeDataBase: MemeRoomDataBase) : UpdateMemeDetailsDataBaseUseCase {
     override fun invoke(memeDetail: MemeDetailRoom) {
         memeDataBase.updateMemeDetailInDataBase(memeDetail)
     }

--- a/domain/src/main/java/com/globant/domain/usecase/implementation/UpdateMemesDataBaseUseCaseImpl.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/implementation/UpdateMemesDataBaseUseCaseImpl.kt
@@ -4,8 +4,7 @@ import com.globant.domain.database.MemeRoomDataBase
 import com.globant.domain.entity.MemeRoom
 import com.globant.domain.usecase.UpdateMemesDataBaseUseCase
 
-class UpdateMemesDataBaseUseCaseImpl(private val memeDataBase: MemeRoomDataBase) :
-    UpdateMemesDataBaseUseCase {
+class UpdateMemesDataBaseUseCaseImpl(private val memeDataBase: MemeRoomDataBase) : UpdateMemesDataBaseUseCase {
     override fun invoke(listOfMemes: List<MemeRoom>) {
         memeDataBase.updateMemesInDataBase(listOfMemes)
     }

--- a/domain/src/main/java/com/globant/domain/usecase/implementation/UpdateMemesDataBaseUseCaseImpl.kt
+++ b/domain/src/main/java/com/globant/domain/usecase/implementation/UpdateMemesDataBaseUseCaseImpl.kt
@@ -1,0 +1,12 @@
+package com.globant.domain.usecase.implementation
+
+import com.globant.domain.database.MemeRoomDataBase
+import com.globant.domain.entity.MemeRoom
+import com.globant.domain.usecase.UpdateMemesDataBaseUseCase
+
+class UpdateMemesDataBaseUseCaseImpl(private val memeDataBase: MemeRoomDataBase) :
+    UpdateMemesDataBaseUseCase {
+    override fun invoke(listOfMemes: List<MemeRoom>) {
+        memeDataBase.updateMemesInDataBase(listOfMemes)
+    }
+}


### PR DESCRIPTION
In this PR I have implemented the base structure for the Room data base that I will connect with the app in the next PR.
 - Data Access Object (Dao) interface implemented to access to the data (GET or INSERT).
 - Added the necessary use cases to get data from data base or to update the data in the data base.
 - Data base singleton injected using Koin. 
 - Data base interface declared in "domain" module and implemented in "data" module.
 - "MemeDetailRoom" and "MemeRoom" are the entities to save the data into the Room data base.
"domain" module image:
![image](https://user-images.githubusercontent.com/61156769/84784294-877e3b80-afc0-11ea-9566-d4afb46ff7c2.png)
"data" module image:
![image](https://user-images.githubusercontent.com/61156769/84784355-95cc5780-afc0-11ea-8093-775cd98d8a63.png)
